### PR TITLE
Removed unneeded comma

### DIFF
--- a/lists/1313161554/list.json
+++ b/lists/1313161554/list.json
@@ -204,6 +204,6 @@
         "decimals": 18,
         "chainId": 1313161554,
         "logoURI": "https://raw.githubusercontent.com/trisolaris-labs/tokens/master/assets/0x5EB99863f7eFE88c447Bc9D52AA800421b1de6c9/logo.png"
-      },
+      }
     ]
   }


### PR DESCRIPTION
Extra comma breaks JSON syntax, causing `yarn build-tokens` to not function correctly